### PR TITLE
let consumers specify custom HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ var travis = new Travis({
     version: '2.0.0',
     pro: true
 });
+
+// To set custom headers
+var travis = new Travis({
+  version: '2.0.0',
+  headers: {
+    'user-agent': 'My Custom User Agent'
+  }
+});
 ```
 
 # API

--- a/lib/travis-ci.js
+++ b/lib/travis-ci.js
@@ -82,7 +82,7 @@ var createFunctionTree = function (context, obj, tree, url) {
 
 var TravisClient = function (config) {
     this.pro = config.pro || false;
-    this.agent = new TravisHttp(this.pro);
+    this.agent = new TravisHttp(this.pro, config.headers);
 
     if (!config.hasOwnProperty('version')) {
         throw 'must specify api version';

--- a/lib/travis-http.js
+++ b/lib/travis-http.js
@@ -5,14 +5,14 @@ var request = require('request');
 var TRAVIS_ENDPOINT = 'https://api.travis-ci.org';
 var TRAVIS_PRO_ENDPOINT = 'https://api.travis-ci.com';
 
-var TravisHttp = function (pro) {
+var TravisHttp = function (pro, headers) {
     this._endpoint = pro ? TRAVIS_PRO_ENDPOINT : TRAVIS_ENDPOINT;
+    this._headers = headers ? JSON.parse(JSON.stringify(headers)) : {};
 };
 
 TravisHttp.prototype._getHeaders = function () {
-    var headers = {
-        'Accept': 'application/vnd.travis-ci.2+json, */*; q=0.01'
-    };
+    var headers = JSON.parse(JSON.stringify(this._headers));
+    headers.Accept = 'application/vnd.travis-ci.2+json, */*; q=0.01';
     if (this._getAccessToken()) {
         headers.Authorization = 'token ' + this._getAccessToken();
     }


### PR DESCRIPTION
In some cases it's helpful for API consumers to be able to set custom HTTP headers, particularly User-Agent, because the Travis API servers will whitelist certain values of that header (in response to problems like https://www.traviscistatus.com/incidents/bntk781kb8y8). This branch adds a *headers* option that accepts custom headers to set on requests.

I'm not sure how to unit test this, as I don't see other unit tests that are checking the values of request headers. But I've confirmed that it enables me to fix a problem with accessing a Travis API endpoint by specifying a whitelisted User-Agent header.
