### PR TITLE
Use json Accept header only

### DIFF
--- a/lib/travis-http.js
+++ b/lib/travis-http.js
@@ -12,7 +12,7 @@ var TravisHttp = function (pro, headers) {
 
 TravisHttp.prototype._getHeaders = function () {
     var headers = JSON.parse(JSON.stringify(this._headers));
-    headers.Accept = 'application/vnd.travis-ci.2+json, */*; q=0.01';
+    headers.Accept = 'application/vnd.travis-ci.2+json';
     if (this._getAccessToken()) {
         headers.Authorization = 'token ' + this._getAccessToken();
     }


### PR DESCRIPTION
Hey,

travis has a bug, that when you try to fetch repository information of a repository that doesn't exist, that it will return an image instead of the json with your headers. However if you use the json type only, it will work. So this change fixes that problem.

Best,
Finn