### PR TITLE
feat: support Travis Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ var travis = new Travis({
     pro: true
 });
 
+// To access the Travis-CI Enterprise API
+var travis = new Travis({
+    version: '2.0.0',
+    enterprise: 'https://travis.example.com'
+});
+
 // To set custom headers
 var travis = new Travis({
   version: '2.0.0',
@@ -60,7 +66,7 @@ travis.auth.github.post({
 });
 ```
 
-As a convenience, `authenticate` also accepts github tokens, or github credentials (which are only sent to github) and performs the necessary requests to aquire a travis access token. For example:
+As a convenience, `authenticate` also accepts github tokens, or github credentials (which are only sent to github) and performs the necessary requests to acquire a travis access token. For example:
 
 ```js
 travis.authenticate({

--- a/lib/travis-ci.js
+++ b/lib/travis-ci.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var assert = require('assert');
+var url = require('url');
 var _ = require('lodash');
 var util = require('util');
 var TravisHttp = require('./travis-http');
 var GitHub = require('github');
-var assert = require('assert');
 
 var PARAM = ':param';
 var TEMP_URI = 'tempUri';
@@ -82,7 +82,24 @@ var createFunctionTree = function (context, obj, tree, url) {
 
 var TravisClient = function (config) {
     this.pro = config.pro || false;
-    this.agent = new TravisHttp(this.pro, config.headers);
+    this.enterprise = false;
+    if (this.pro) {
+        this.travisUrl = 'https://travis-ci.com';
+        this.travisApiUrl = 'https://api.travis-ci.com';
+    } else if (config.enterprise) {
+        var parsedUrl = url.parse(config.enterprise);
+
+        assert(parsedUrl.protocol && parsedUrl.host, 'Expected a valid URL, got ' + config.enterprise);
+
+        this.travisUrl = parsedUrl.protocol + '//' + parsedUrl.host;
+        this.travisApiUrl = this.travisUrl + '/api';
+        this.enterprise = true;
+    } else {
+        this.travisUrl =  'https://travis-ci.org';
+        this.travisApiUrl =  'https://api.travis-ci.org';
+    }
+
+    this.agent = new TravisHttp(this.travisApiUrl, config.headers);
 
     if (!config.hasOwnProperty('version')) {
         throw 'must specify api version';
@@ -126,6 +143,7 @@ TravisClient.prototype._authenticateBasic = function (msg, callback) {
     assert(msg.hasOwnProperty('username'), msg);
     assert(msg.hasOwnProperty('password'), msg);
     assert(_.isFunction(callback));
+    assert(!this.enterprise, 'basic authentication cannot be used with Travis Enterprise');
 
     var GITHUB_TRAVIS_APP_INFO = {
         app: {

--- a/lib/travis-ci.js
+++ b/lib/travis-ci.js
@@ -84,18 +84,15 @@ var TravisClient = function (config) {
     this.pro = config.pro || false;
     this.enterprise = false;
     if (this.pro) {
-        this.travisUrl = 'https://travis-ci.com';
         this.travisApiUrl = 'https://api.travis-ci.com';
     } else if (config.enterprise) {
         var parsedUrl = url.parse(config.enterprise);
 
         assert(parsedUrl.protocol && parsedUrl.host, 'Expected a valid URL, got ' + config.enterprise);
 
-        this.travisUrl = parsedUrl.protocol + '//' + parsedUrl.host;
-        this.travisApiUrl = this.travisUrl + '/api';
+        this.travisApiUrl = parsedUrl.protocol + '//' + parsedUrl.host + '/api';
         this.enterprise = true;
     } else {
-        this.travisUrl =  'https://travis-ci.org';
         this.travisApiUrl =  'https://api.travis-ci.org';
     }
 

--- a/lib/travis-http.js
+++ b/lib/travis-http.js
@@ -2,11 +2,8 @@
 
 var request = require('request');
 
-var TRAVIS_ENDPOINT = 'https://api.travis-ci.org';
-var TRAVIS_PRO_ENDPOINT = 'https://api.travis-ci.com';
-
-var TravisHttp = function (pro, headers) {
-    this._endpoint = pro ? TRAVIS_PRO_ENDPOINT : TRAVIS_ENDPOINT;
+var TravisHttp = function (endpoint, headers) {
+    this._endpoint = endpoint;
     this._headers = headers ? JSON.parse(JSON.stringify(headers)) : {};
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,26 @@ describe('travis ci api test suite', function () {
         thrower.should.throw();
     });
 
+    it('expects enterprise to be valid URL', function () {
+        var thrower = function () {
+            new TravisCi({
+                version: '2.0.0',
+                enterprise: 'some string'
+            });
+        };
+        thrower.should.throw();
+    });
+
+    it('enterpise url i protocol + host + /api', function () {
+        var travis = new TravisCi({
+            version: '2.0.0',
+            enterprise: 'https://travis.example.com/something-weird'
+        });
+
+        travis.travisUrl.should.equal('https://travis.example.com');
+        travis.travisApiUrl.should.equal('https://travis.example.com/api');
+    });
+
     it('only supports version 2.0.0', function () {
         var thrower = function () {
             new TravisCi({
@@ -126,7 +146,7 @@ describe('travis ci api test suite', function () {
             // and if that test exists, run it
             _.each(routeSection.routes, function (route) {
                 var testName = 'tests ' + route.verb + ' ' + route.uri;
-                
+
                 it(testName, function () {
                     if (!_.findWhere(routeSectionEndpointTests, {
                         uri: route.uri,

--- a/test/index.js
+++ b/test/index.js
@@ -28,13 +28,12 @@ describe('travis ci api test suite', function () {
         thrower.should.throw();
     });
 
-    it('enterpise url i protocol + host + /api', function () {
+    it('makes enterprise url be protocol + host + /api', function () {
         var travis = new TravisCi({
             version: '2.0.0',
             enterprise: 'https://travis.example.com/something-weird'
         });
 
-        travis.travisUrl.should.equal('https://travis.example.com');
         travis.travisApiUrl.should.equal('https://travis.example.com/api');
     });
 


### PR DESCRIPTION
Fixes #21 

The instance of Travis enterprise I'm testing against is behind 2fa, so I'm unable to test basic auth. For now I just throw if basic auth is attempted. Is that ok?

I was also unable to run the tests. Ideas on tests to add?

My test script which resolved to a token:

```js
const Travis = require('./');
const {promisify} = require('util');

const travis = new Travis({
    version: '2.0.0',
    enterprise: 'https://travis.schibsted.io',
});

promisify(travis.authenticate.bind(travis))({github_token: process.env.TOKEN}).then(console.log, console.error)
```

/cc @dlmr