### PR TITLE
migrate from github to @octokit/rest

### DIFF
--- a/lib/travis-ci.js
+++ b/lib/travis-ci.js
@@ -5,7 +5,7 @@ var url = require('url');
 var _ = require('lodash');
 var util = require('util');
 var TravisHttp = require('./travis-http');
-var GitHub = require('github');
+var GitHub = require('@octokit/rest');
 
 var PARAM = ':param';
 var TEMP_URI = 'tempUri';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/pwmckenna/node-travis-ci",
   "bugs": "https://github.com/pwmckenna/node-travis-ci/issues",
   "dependencies": {
-    "github": "~0.1.10",
+    "@octokit/rest": "~15.10.0",
     "lodash": "~1.3.1",
     "request": "^2.87.0",
     "underscore.string": "~2.2.0rc"


### PR DESCRIPTION
I made these changes in the GitHub editor. I just noticed this message when installing `travis-ci`:

> npm WARN deprecated github@0.1.16: 'github' has been renamed to '@octokit/rest' (https://git.io/vNB11)

It looks like the version of the `github` module used in this package is quite old, so I'm guessing there will be some differences in functionality, though I haven't tested it.

My interest here is simply to help out, but I have no real need of this update. I just figured a PR was a step above a quick "FYI issue." Feel free to do whatever you like with this :)